### PR TITLE
Use static constant and replace Redirect with ModifyArg

### DIFF
--- a/src/main/java/carpet/mixins/ChatHud_chatUpMixin.java
+++ b/src/main/java/carpet/mixins/ChatHud_chatUpMixin.java
@@ -1,31 +1,30 @@
 package carpet.mixins;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.hud.ChatHud;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ChatHud.class)
 public class ChatHud_chatUpMixin
 {
-    public final int OFFSET = 10;
+    private static final int CHAT_UP_OFFSET = 10;
 
-    @Redirect(method = "render", at = @At(
+    @ModifyArg(method = "render", index = 1, at = @At(
             value = "INVOKE",
             target = "Lcom/mojang/blaze3d/systems/RenderSystem;translatef(FFF)V",
             ordinal = 0
     ))
-    private void moveUp(float x, float y, float z)
+    private float offsetY(float y)
     {
-        RenderSystem.translatef(x, y-OFFSET, z);
+        return y- CHAT_UP_OFFSET;
     }
 
     @ModifyConstant(method = "getText", constant = @Constant(doubleValue = 40.0), expect = 1)
     private double textBottomOffset(double original)
     {
-        return original+OFFSET;
+        return original+ CHAT_UP_OFFSET;
     }
 }


### PR DESCRIPTION
- There is no need for the offset to be anything but a compile-time constant, so I have made it so here. I also renamed the constant to include your mod's name; it is worth noting that anything declared in a mixin class is copied into the target. So currently your mixin has been copying an ambiguous `offset` field into the class.

- `ModifyArg` is much less intrusive; your code has no intention of modifying `x` and `z` so there is no reason to capture them with a `Redirect`. 

I would also strongly recommend using domain naming conventions for your code to ensure it is unique and identifiable. In this case, the current package doesn't even relate to this mod. Following standard conventions, the group/package for this mod should ideally be `com.github.gnembon.chatup`.