### PR TITLE
Made offset dynamic

### DIFF
--- a/src/main/java/carpet/mixins/ChatHud_chatUpMixin.java
+++ b/src/main/java/carpet/mixins/ChatHud_chatUpMixin.java
@@ -1,7 +1,11 @@
 package carpet.mixins;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.network.ClientPlayerEntity;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -10,7 +14,16 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(ChatHud.class)
 public class ChatHud_chatUpMixin
 {
-    private static final int CHAT_UP_OFFSET = 10;
+    @Shadow @Final private MinecraftClient client;
+
+    private int getOffset()
+    {
+        ClientPlayerEntity player = this.client.player;
+        if(player == null || player.isCreative() || player.isSpectator()) return 0;
+        int offset = player.getArmor()>0?10:0;
+        if(player.getAbsorptionAmount()>0) offset += 10;
+        return offset;
+    }
 
     @ModifyArg(method = "render", index = 1, at = @At(
             value = "INVOKE",
@@ -19,12 +32,12 @@ public class ChatHud_chatUpMixin
     ))
     private float offsetY(float y)
     {
-        return y- CHAT_UP_OFFSET;
+        return y - getOffset();
     }
 
     @ModifyConstant(method = "getText", constant = @Constant(doubleValue = 40.0), expect = 1)
     private double textBottomOffset(double original)
     {
-        return original+ CHAT_UP_OFFSET;
+        return original + getOffset();
     }
 }


### PR DESCRIPTION
This makes the chat offset change, depending on if the armor bar is visible, and if the player has absorption hearts.
Suggested in #5, fixes #3

I decided to now make it go higher if there are more than 1 row of absorption hearts, since you wouldn't want chat to go off screen, and more than one row is not achievable anyway (afaik)